### PR TITLE
修复 ChainGetParentMessage 数据解析为空数据Bug

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -20,7 +20,7 @@ func (c *Client) ChainGetBlockMessages(ctx context.Context, id cid.Cid) (*types.
 }
 
 // ChainHead returns the current head of the chain.
-func (c *Client) ChainHead(ctx context.Context, ) (*types.TipSet, error) {
+func (c *Client) ChainHead(ctx context.Context) (*types.TipSet, error) {
 	var ts *types.TipSet
 	return ts, c.Request(ctx, c.FilecoinMethod("ChainHead"), &ts)
 }
@@ -56,8 +56,8 @@ func (c *Client) ChainGetNode(ctx context.Context, p string) (*types.IpldObject,
 }
 
 // ChainGetParentMessages returns messages stored in parent tipset of the specified block.
-func (c *Client) ChainGetParentMessages(ctx context.Context, id cid.Cid) ([]types.Message, error) {
-	var msgs []types.Message
+func (c *Client) ChainGetParentMessages(ctx context.Context, id cid.Cid) ([]types.ParentMessage, error) {
+	var msgs []types.ParentMessage
 	return msgs, c.Request(ctx, c.FilecoinMethod("ChainGetParentMessages"), &msgs, id)
 }
 

--- a/chain_test.go
+++ b/chain_test.go
@@ -2,6 +2,7 @@ package filecoin
 
 import (
 	"context"
+	"github.com/filecoin-project/go-address"
 	"github.com/ipfs/go-cid"
 	"testing"
 )
@@ -62,5 +63,32 @@ func TestClient_ChainGetTipSetByHeight(t *testing.T) {
 		for index, msg := range bm.BlsMessages {
 			t.Log(bm.Cids[index], msg)
 		}
+	}
+}
+
+// 遍历区块的 parentMessages
+func TestClient_ChainGetParentMessages(t *testing.T) {
+	var blockHeight int64 = 646458
+	c := testClient()
+	tipSet, err := c.ChainGetTipSetByHeight(context.Background(), blockHeight, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	//同一个 tipSet 下的 block 的 parentMessages 相同
+	pms, err := c.ChainGetParentMessages(context.Background(), tipSet.Cids[0])
+	if err != nil {
+		t.Error(err)
+	}
+	t.Log(len(pms))
+	for _, pm := range pms {
+		address.CurrentNetwork = address.Mainnet
+		cid := pm.Cid.Cid
+		from := pm.Message.From.String()
+		to := pm.Message.To.String()
+		value := pm.Message.Value
+		t.Log(cid)
+		t.Log(from)
+		t.Log(to)
+		t.Log(value)
 	}
 }

--- a/types/message.go
+++ b/types/message.go
@@ -25,6 +25,15 @@ type Message struct {
 	Params     []byte          `json:"Params"`
 }
 
+type ParentMessage struct {
+	Cid     Cid     `json:"Cid"`
+	Message Message `json:"Message"`
+}
+
+type Cid struct {
+	Cid string `json:"/"`
+}
+
 func (m *Message) Caller() address.Address {
 	return m.From
 }


### PR DESCRIPTION
ChainGetParentMessage  数据结构可能是官方做了更改，获取到的数据全部字段都是初始值，所以进行了简单的修改